### PR TITLE
77 Remove -d shortform flag for debug since it conflicts with analyze…

### DIFF
--- a/r2c/cli/commands/run.py
+++ b/r2c/cli/commands/run.py
@@ -103,8 +103,7 @@ class InteractiveCommand(click.Command):
     default=False,
 )
 @click.option(
-    "--debug",
-    "-d",
+    "--debug", 
     is_flag=True,
     help="Show extra output, error messages, and exception stack traces with DEBUG filtering",
     default=False,


### PR DESCRIPTION
The -d flag for debug conflicts with -d for the --analyzer-directory flag. Removing -d for debug will allow debug to be run with --debug only, and -d will work properly for analyzer directory.